### PR TITLE
Execute droonga-http-server --version via run_as_user()

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -304,7 +304,7 @@ download_url() {
 }
 
 installed_version() {
-  $NAME --version
+  run_as_user $NAME --version
 }
 
 register_service() {


### PR DESCRIPTION
I'm so sorry. My last pull request includes important mistake that prevent us to install droonga-http-server specified version.
